### PR TITLE
Corrigir avisos do PHPStan em YoutubeClient

### DIFF
--- a/lib/YoutubeClient.php
+++ b/lib/YoutubeClient.php
@@ -8,42 +8,83 @@ final class YoutubeClient
 
     public function __construct(?string $key = null) {
         $this->key = $key ?? Config::ytApiKey();
-        if ($this->key === '') throw new \RuntimeException('YT_API_KEY not configured.');
+        if ($this->key === '') {
+            throw new \RuntimeException('YT_API_KEY not configured.');
+        }
     }
 
+    /**
+     * Faz uma requisição GET à API do YouTube.
+     *
+     * @param array<string, string|int|null> $query  Query string (será mesclada com a API key)
+     * @return array<string,mixed>                   Decodificado como array associativo
+     */
     private function get(string $path, array $query): array {
         $query['key'] = $this->key;
+
         $url = self::BASE . $path . '?' . http_build_query($query);
-        $ch = curl_init($url);
-        curl_setopt_array($ch, [CURLOPT_RETURNTRANSFER=>true, CURLOPT_TIMEOUT=>15]);
-        $res = curl_exec($ch);
-        $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $ch  = curl_init($url);
+
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT        => 15,
+        ]);
+
+        /** @var string|false $res */
+        $res  = curl_exec($ch);
+        /** @var int $code */
+        $code = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
         $err  = curl_error($ch);
         curl_close($ch);
-        if ($res === false || $code < 200 || $code >= 300) {
+
+        // Erro na requisição
+        if (!is_string($res) || $code < 200 || $code >= 300) {
             throw new \RuntimeException("YouTube API error: HTTP $code - $err");
         }
-        return json_decode($res, true) ?? [];
+
+        $data = json_decode($res, true);
+
+        // Erro ao decodificar JSON
+        if (!is_array($data)) {
+            $data = [];
+        }
+
+        /** @var array<string,mixed> $data */
+        return $data;
     }
 
+    /**
+     * Chamada ao endpoint /search.
+     *
+     * @return array<string,mixed>
+     */
     public function search(string $topic, string $lang, string $country, ?string $pageToken): array {
         return $this->get('/search', array_filter([
-            'part' => 'snippet',
-            'type' => 'video',
-            'q' => $topic,
+            'part'              => 'snippet',
+            'type'              => 'video',
+            'q'                 => $topic,
             'relevanceLanguage' => $lang,
-            'regionCode' => $country,
-            'maxResults' => 25,
-            'pageToken' => $pageToken,
-        ]));
+            'regionCode'        => $country,
+            'maxResults'        => 25,
+            'pageToken'         => $pageToken,
+        ], static fn($v) => $v !== null && $v !== ''));
     }
 
+    /**
+     * Chamada ao endpoint /channels.
+     *
+     * @param list<string> $ids
+     * @return array<string,mixed>
+     */
     public function channels(array $ids): array {
-        if (!$ids) return ['items'=>[]];
+        if ($ids === []) {
+            return ['items' => []];
+        }
+
         return $this->get('/channels', [
-            'part' => 'snippet,statistics,topicDetails',
-            'id' => implode(',', $ids),
-            'maxResults' => 50
+            'part'       => 'snippet,statistics,topicDetails',
+            'id'         => implode(',', $ids),
+            'maxResults' => 50,
         ]);
     }
 }


### PR DESCRIPTION
## Contexto
Ao rodar `composer stan` (nível `max`), o PHPStan apontava:
- Falta de **value type** em arrays de parâmetros/retornos (`get()`, `search()`, `channels()`).
- Possível retorno **mixed** em `get()`.
- `json_decode` recebendo tipo não garantido (string|true).
  
Objetivo: esclarecer contratos de tipos, manter o nível `max` sem silenciar regras.

## O que foi feito
- **`get()`**
  - `@param array<string,string|int|null> $query`
  - `@return array<string,mixed>`
  - Garantia de que `curl_exec` retorna **string** antes de `json_decode`; exceção com HTTP code + erro do cURL.
  - Normalização do `json_decode` para array (`[]` se não for array).
- **`search()`**
  - `@return array<string,mixed>`
  - `array_filter(..., static fn($v) => $v !== null && $v !== '')` para ajudar o analisador.
- **`channels()`**
  - `@param list<string> $ids`
  - `@return array<string,mixed>`
  - Curto-circuito quando `[]` → `['items' => []]`.

## Resultado
- `composer stan` sem avisos no `YoutubeClient` (nível `max`).
- Nenhuma mudança de comportamento funcional; apenas contratos de tipos e validações mais explícitas.

## Como testar
```bash
composer install
composer stan
```

## Issues
* Relates to #4 
* Closes #4 